### PR TITLE
Ruby Version Anheben

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.4'
           bundler-cache: true
 
       - name: Install Jekyll dependencies


### PR DESCRIPTION
Von https://www.ruby-lang.org/de/news/2025/02/14/ruby-3-4-2-released/